### PR TITLE
sdcardfs: Flag files as non-mappable

### DIFF
--- a/fs/sdcardfs/file.c
+++ b/fs/sdcardfs/file.c
@@ -227,6 +227,7 @@ static int sdcardfs_open(struct inode *inode, struct file *file)
 	/* save current_cred and override it */
 	OVERRIDE_CRED(sbi, saved_cred);
 
+	file->f_mode |= FMODE_NONMAPPABLE;
 	file->private_data =
 		kzalloc(sizeof(struct sdcardfs_file_info), GFP_KERNEL);
 	if (!SDCARDFS_F(file)) {
@@ -323,6 +324,11 @@ static int sdcardfs_fasync(int fd, struct file *file, int flag)
 	return err;
 }
 
+static struct file *sdcardfs_get_lower_file(struct file *f)
+{
+	return sdcardfs_lower_file(f);
+}
+
 const struct file_operations sdcardfs_main_fops = {
 	.llseek		= generic_file_llseek,
 	.read		= sdcardfs_read,
@@ -337,6 +343,7 @@ const struct file_operations sdcardfs_main_fops = {
 	.release	= sdcardfs_file_release,
 	.fsync		= sdcardfs_fsync,
 	.fasync		= sdcardfs_fasync,
+	.get_lower_file = sdcardfs_get_lower_file,
 };
 
 /* trimmed directory options */
@@ -353,4 +360,5 @@ const struct file_operations sdcardfs_dir_fops = {
 	.flush		= sdcardfs_flush,
 	.fsync		= sdcardfs_fsync,
 	.fasync		= sdcardfs_fasync,
+	.get_lower_file = sdcardfs_get_lower_file,
 };

--- a/include/linux/fs.h
+++ b/include/linux/fs.h
@@ -135,6 +135,9 @@ typedef void (dio_iodone_t)(struct kiocb *iocb, loff_t offset,
 /* Has write method(s) */
 #define FMODE_CAN_WRITE         ((__force fmode_t)0x40000)
 
+/* File hasn't page cache and can't be mmaped, for stackable filesystem */
+#define FMODE_NONMAPPABLE       ((__force fmode_t)0x400000)
+
 /* File was opened by fanotify and shouldn't generate fanotify events */
 #define FMODE_NONOTIFY		((__force fmode_t)0x1000000)
 
@@ -1529,6 +1532,7 @@ struct file_operations {
 	long (*fallocate)(struct file *file, int mode, loff_t offset,
 			  loff_t len);
 	int (*show_fdinfo)(struct seq_file *m, struct file *f);
+	struct file* (*get_lower_file)(struct file *f);
 };
 
 struct inode_operations {

--- a/mm/mmap.c
+++ b/mm/mmap.c
@@ -1280,6 +1280,9 @@ unsigned long do_mmap_pgoff(struct file *file, unsigned long addr,
 
 	*populate = 0;
 
+	while (file && (file->f_mode & FMODE_NONMAPPABLE))
+		file = file->f_op->get_lower_file(file);
+
 #ifdef CONFIG_MSM_APP_SETTINGS
 	if (file && file->f_path.dentry) {
 		const char *name = file->f_path.dentry->d_name.name;


### PR DESCRIPTION
Implement Samsung's FMODE_NONMAPPABLE flag from
sdcardfs version 2.1.4 as we hit a BUG on ext4:

[   49.655037]@0 Kernel BUG at ffffffc0001deeec [verbose debug info unavailable]
[   49.655045]@0 Internal error: Oops - BUG: 0 [#1] PREEMPT SMP
[   49.655052]@0 Modules linked in:
[   49.655061]@0 CPU: 0 PID: 283 Comm: kworker/u8:7 Tainted: G        W      3.18.20-perf-g3be2054-00086-ga8307fb #1
[   49.655070]@0 Hardware name: Qualcomm Technologies, Inc. MSM 8996 v3 + PMI8996 MTP (DT)
[   49.655077]@0 Workqueue: writeback bdi_writeback_workfn (flush-8:0)
[   49.655096]@0 task: ffffffc174ba8b00 ti: ffffffc174bb4000 task.ti: ffffffc174bb4000
[   49.655108]@0 PC is at mpage_prepare_extent_to_map+0x198/0x218
[   49.655116]@0 LR is at mpage_prepare_extent_to_map+0x110/0x218
[   49.655121]@0 pc : [<ffffffc0001deeec>] lr : [<ffffffc0001dee64>] pstate: 60000145
[   49.655126]@0 sp : ffffffc174bb7800
[   49.655130]@0 x29: ffffffc174bb7800 x28: ffffffc174bb7880
[   49.655140]@0 x27: 000000000000000d x26: ffffffc1245505e8
[   49.655149]@0 x25: 0000000000000000 x24: 0000000000003400
[   49.655160]@0 x23: ffffffffffffffff x22: 0000000000000000
[   49.655172]@0 x21: ffffffc174bb7888 x20: ffffffc174bb79e0
[   49.655182]@0 x19: ffffffbdc4ee7b80 x18: 0000007f92872000
[   49.655191]@0 x17: 0000007f959b6424 x16: ffffffc00016d1ac
[   49.655201]@0 x15: 0000007f9285d158 x14: ffffffc1734796e8
[   49.655210]@0 x13: ffffffbdc1ffa4c0 x12: ffffffbdc4ee7b80
[   49.655220]@0 x11: 0000000000000100 x10: 0000000000000000
[   49.655229]@0 x9 : 0000000000000000 x8 : ffffffc0b444e210
[   49.655237]@0 x7 : 0000000000000000 x6 : ffffffc0b444e1e0
[   49.655246]@0 x5 : 0000000000000000 x4 : 0000000000000001
[   49.655254]@0 x3 : 0000000000000000 x2 : 400000000002003d
[   49.655263]@0 x1 : ffffffbdc4ee7b80 x0 : 400000000002003d
[   49.655271]@0
[   49.656502]@0 Process kworker/u8:7 (pid: 283, stack limit = 0xffffffc174bb4058)
[   49.656509]@0 Call trace:
[   49.656514]@0 [<ffffffc0001deeec>] mpage_prepare_extent_to_map+0x198/0x218
[   49.656526]@0 [<ffffffc0001e28d0>] ext4_writepages+0x270/0xa58
[   49.656533]@0 [<ffffffc00012982c>] do_writepages+0x24/0x40
[   49.656541]@0 [<ffffffc000180160>] __writeback_single_inode+0x40/0x114
[   49.656549]@0 [<ffffffc000180e50>] writeback_sb_inodes+0x1dc/0x34c
[   49.656555]@0 [<ffffffc00018103c>] __writeback_inodes_wb+0x7c/0xc4
[   49.656560]@0 [<ffffffc000181224>] wb_writeback+0x110/0x1a8
[   49.656565]@0 [<ffffffc000181344>] wb_check_old_data_flush+0x88/0x98
[   49.656571]@0 [<ffffffc00018156c>] bdi_writeback_workfn+0xf4/0x1fc
[   49.656576]@0 [<ffffffc0000b14f8>] process_one_work+0x1e0/0x300
[   49.656585]@0 [<ffffffc0000b1e14>] worker_thread+0x318/0x438
[   49.656590]@0 [<ffffffc0000b5da0>] kthread+0xe0/0xec
[   49.656598]@0 Code: f9400260 f9400a63 1ad92063 37580040 (e7f001f2)
[   49.656604]@0 ---[ end trace cbed09f772fd630d ]---

Change-Id: I931da7cb3841db1f130dba298a7d256b6f02d1bc